### PR TITLE
Update to latest `node-forge`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Ryan Seys",
   "license": "MIT",
   "dependencies": {
-    "node-forge": "^0.6.33"
+    "node-forge": "^0.6.46"
   },
   "devDependencies": {
     "mocha": "2.0.1"


### PR DESCRIPTION
This picks up the fix for https://github.com/digitalbazaar/forge/pull/445, which makes this library no longer throw under `jest` automocked tests.